### PR TITLE
Fix AI plan rest days to follow calendar weekdays

### DIFF
--- a/js/manual-plan-system.js
+++ b/js/manual-plan-system.js
@@ -400,11 +400,9 @@ const DQ_MANUAL_PLAN = {
     },
 
     getCycleDayIndex(state, todayStr, cycleLength = 7) {
-        const startRaw = String(state?.startedAt || todayStr).slice(0, 10);
-        const start = new Date(`${startRaw}T00:00:00`);
-        const today = new Date(`${todayStr}T00:00:00`);
-        const diffDays = Math.max(0, Math.floor((today.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)));
-        return diffDays % Math.max(1, cycleLength || 7);
+        const today = new Date(`${todayStr}T12:00:00`);
+        const mondayBasedDayIndex = (today.getDay() + 6) % 7;
+        return mondayBasedDayIndex % Math.max(1, cycleLength || 7);
     },
 
     async getAiScheduledQuestSet(customPlan, settings, state, todayStr, difficulty, hasEquipment, customExercises) {

--- a/tests/19-ai-plan-weekday-schedule.test.js
+++ b/tests/19-ai-plan-weekday-schedule.test.js
@@ -1,0 +1,65 @@
+/**
+ * Test 19: KI-Plan-Wochentage.
+ * Stellt sicher, dass day 1..7 immer Montag..Sonntag bedeutet und nicht
+ * relativ zum Import- oder Aktivierungsdatum verschoben wird.
+ */
+const { TestRunner, BASE } = require('./helpers');
+const fs = require('fs');
+const path = require('path');
+
+function loadManualPlan() {
+    global.window = global;
+    const code = fs.readFileSync(path.join(BASE, 'js/manual-plan-system.js'), 'utf8');
+    new Function(code)();
+    return global.DQ_MANUAL_PLAN;
+}
+
+function run() {
+    const t = new TestRunner('KI-Plan-Wochentage');
+    const manualPlan = loadManualPlan();
+
+    const stateStartedOnSunday = { startedAt: '2026-08-09T12:00:00.000Z' };
+
+    t.equal(
+        manualPlan.getCycleDayIndex(stateStartedOnSunday, '2026-08-10', 7),
+        0,
+        'Montag bleibt day 1, auch wenn der KI-Plan am Sonntag gestartet wurde'
+    );
+    t.equal(
+        manualPlan.getCycleDayIndex(stateStartedOnSunday, '2026-08-11', 7),
+        1,
+        'Dienstag entspricht day 2'
+    );
+    t.equal(
+        manualPlan.getCycleDayIndex(stateStartedOnSunday, '2026-08-15', 7),
+        5,
+        'Samstag entspricht day 6'
+    );
+    t.equal(
+        manualPlan.getCycleDayIndex(stateStartedOnSunday, '2026-08-16', 7),
+        6,
+        'Sonntag entspricht day 7'
+    );
+
+    const schedule = [
+        { day: 1, kind: 'training' },
+        { day: 2, kind: 'rest' },
+        { day: 3, kind: 'training' },
+        { day: 4, kind: 'training' },
+        { day: 5, kind: 'training' },
+        { day: 6, kind: 'rest' },
+        { day: 7, kind: 'training' }
+    ];
+
+    const monday = schedule[manualPlan.getCycleDayIndex(stateStartedOnSunday, '2026-08-10', 7)];
+    const tuesday = schedule[manualPlan.getCycleDayIndex(stateStartedOnSunday, '2026-08-11', 7)];
+    const saturday = schedule[manualPlan.getCycleDayIndex(stateStartedOnSunday, '2026-08-15', 7)];
+
+    t.equal(monday.kind, 'training', 'Montag wird bei Dienstag/Samstag-Restdays als Training erkannt');
+    t.equal(tuesday.kind, 'rest', 'Dienstag bleibt Restday');
+    t.equal(saturday.kind, 'rest', 'Samstag bleibt Restday');
+
+    return t;
+}
+
+module.exports = { run, name: '19-ai-plan-weekday-schedule' };


### PR DESCRIPTION
## Was geändert wurde

KI-generierte 7-Tage-Pläne werden jetzt an echte Kalenderwochentage gebunden:

- `day: 1` = Montag
- `day: 2` = Dienstag
- `day: 3` = Mittwoch
- `day: 4` = Donnerstag
- `day: 5` = Freitag
- `day: 6` = Samstag
- `day: 7` = Sonntag

## Ursache

Bisher wurde der aktuelle KI-Plan-Tag aus der Anzahl der Tage seit `state.startedAt` berechnet. Dadurch begann `day: 1` am Import- bzw. Aktivierungstag des Plans statt zwingend am Montag. Wurde ein Plan beispielsweise am Sonntag gestartet, konnte der darauffolgende Montag bereits als `day: 2` gelten und dadurch fälschlich ein Restday sein.

## Fix

`getCycleDayIndex()` bestimmt den Plan-Tag jetzt aus dem lokalen Wochentag. Die bestehende 7-Tage-Schedule kann dadurch unverändert bleiben, wird aber korrekt Montag bis Sonntag interpretiert.

## Tests

Neuer Regressionstest `tests/19-ai-plan-weekday-schedule.test.js` prüft insbesondere:

- Montag bleibt `day: 1`, selbst wenn der Plan am Sonntag gestartet wurde
- Dienstag ist `day: 2`
- Samstag ist `day: 6`
- Bei Restdays Dienstag und Samstag bleibt Montag ein Trainingstag

## Auswirkung

Bereits importierte KI-Pläne profitieren ebenfalls von der Korrektur. Die Phasenprogression bleibt weiterhin an `startedAt` gebunden, nur die Tageszuordnung des 7-Tage-Plans wird korrigiert.